### PR TITLE
Init experiment for automatic language boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+sqlite
+eco
+flowblade
+wordpress
+lua
+sqlite.tar.gz
+wordpress*.tar.gz
+javastdlib5
+phpfiles
+sqlfiles

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,140 @@
+RERUNDIR=
+HISTOK=True
+
+all: luastmts.json javastmts.json phpstmts.json sqlstmts.json phpfiles/about.php sqlfiles/99.sql
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua ../../../log_limit_on_090419
+	cd eco/lib/eco; pypy fuzzylboxstats.py java ../../../log_limit_on_090419
+	cd eco/lib/eco; pypy fuzzylboxstats.py php ../../../log_limit_on_090419
+	cd eco/lib/eco; pypy fuzzylboxstats.py sql ../../../log_limit_on_090419
+
+	mkdir -p log/
+	mv eco/lib/eco/*_log.json log/
+	mv eco/lib/eco/*_fail.json log/
+	mv eco/lib/eco/*_run.json log/
+
+comp_exprs: java_expr php_expr lua_expr sql_expr
+	mkdir -p log_exprs
+	mv eco/lib/eco/*.json log_exprs
+
+comp_funcs: java_func php_func lua_func
+	mkdir -p log_funcs
+	mv eco/lib/eco/*.json log_funcs
+
+# Compose functions
+
+java_func: javastdlib5 phpfuncs.json luafuncs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py java15.eco method_declaration php.eco    class_statement javastdlib5/ java phpfuncs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py java15.eco method_declaration lua5_3.eco stat            javastdlib5/ java luafuncs.json $(HISTOK) $(RERUNDIR)
+
+php_func: phpfiles luafuncs.json javafuncs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py php.eco class_statement lua5_3.eco stat               phpfiles/ php luafuncs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py php.eco class_statement java15.eco method_declaration phpfiles/ php javafuncs.json $(HISTOK) $(RERUNDIR)
+
+lua_func: lua phpfuncs.json javafuncs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua5_3.eco stat php.eco    class_statement    lua/testes lua phpfuncs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua5_3.eco stat java15.eco method_declaration lua/testes lua javafuncs.json $(HISTOK) $(RERUNDIR)
+
+# Compose expressions
+
+java_expr: javastdlib5 phpexprs.json sqlstmts.json luaexprs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py java15.eco unary_expression php.eco    expr_without_variable javastdlib5/ java phpexprs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py java15.eco unary_expression sqlite.eco None                  javastdlib5/ java sqlstmts.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py java15.eco unary_expression lua5_3.eco explist               javastdlib5/ java luaexprs.json $(HISTOK) $(RERUNDIR)
+
+php_expr: phpfiles javaexprs.json sqlstmts.json luaexprs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py php.eco expr_without_variable java15.eco assignment_expression phpfiles/ php phpexprs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py php.eco expr_without_variable sqlite.eco None                  phpfiles/ php sqlstmts.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py php.eco expr_without_variable lua5_3.eco explist               phpfiles/ php luaexprs.json $(HISTOK) $(RERUNDIR)
+
+lua_expr: lua javaexprs.json phpexprs.json sqlstmts.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua5_3.eco explist java15.eco assignment_expression lua/testes lua javaexprs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua5_3.eco explist php.eco    expr_without_variable lua/testes lua phpexprs.json  $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py lua5_3.eco explist sqlite.eco None                  lua/testes lua sqlstmts.json  $(HISTOK) $(RERUNDIR)
+
+sql_expr: sqlfiles javaexprs.json phpexprs.json luaexprs.json
+	cd eco/lib/eco; pypy fuzzylboxstats.py sqlite.eco expr java15.eco assignment_expression sqlfiles/ sql javaexprs.json $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py sqlite.eco expr php.eco    expr_without_variable sqlfiles/ sql phpexprs.json  $(HISTOK) $(RERUNDIR)
+	cd eco/lib/eco; pypy fuzzylboxstats.py sqlite.eco expr lua5_3.eco explist               sqlfiles/ sql luaexprs.json  $(HISTOK) $(RERUNDIR)
+
+# Dependencies
+
+sqlite:
+	wget https://www.sqlite.org/src/tarball/sqlite.tar.gz?r=release -O sqlite.tar.gz
+	tar xf sqlite.tar.gz
+
+wordpress:
+	wget https://wordpress.org/wordpress-4.6.13.tar.gz
+	tar xf wordpress-4.6.13.tar.gz
+
+flowblade:
+	git clone https://github.com/jliljebl/flowblade.git
+
+eco:
+	git clone https://github.com/softdevteam/eco
+	cd eco; git checkout lboxstats
+	cp extractor.py eco/lib/eco
+	cp fuzzylboxstats.py eco/lib/eco
+
+lua:
+	git clone https://github.com/lua/lua.git
+
+# Extract expressions, functions, etc.
+
+sqltests.json: sqlite
+	python extractsqltests.py
+
+sqlstmts.json: sqltests.json eco
+	cp extractsqlstmts.py eco/lib/eco
+	cd eco/lib/eco; python2 extractsqlstmts.py ../../../sqltests.json
+
+phpexprs.json: wordpress eco
+	cp extractphp.py eco/lib/eco
+	cd eco/lib/eco; python2 extractphp.py expressions ../../../phpexprs.json
+
+phpfuncs.json: wordpress eco
+	cp extractor.py eco/lib/eco
+	cp extractphp.py eco/lib/eco
+	cd eco/lib/eco; pypy extractphp.py functions ../../../phpfuncs.json
+
+pythonstmts.json: flowblade eco
+	cp extractpython.py eco/lib/eco
+	cd eco/lib/eco; python2 extractpython.py ../../../pythonstmts.json
+
+luaexprs.json: lua eco
+	cp extractlua.py eco/lib/eco
+	cd eco/lib/eco; python2 extractlua.py expressions ../../../luaexprs.json
+
+luafuncs.json: lua eco
+	cp extractlua.py eco/lib/eco
+	cd eco/lib/eco; python2 extractlua.py functions ../../../luafuncs.json
+
+javaexprs.json: javastdlib5 eco
+	cp extractjava.py eco/lib/eco
+	cd eco/lib/eco; python2 extractjava.py expressions ../../../javaexprs.json
+
+javafuncs.json: javastdlib5 eco
+	cp extractjava.py eco/lib/eco
+	cd eco/lib/eco; python2 extractjava.py functions ../../../javafuncs.json
+
+# Extract programs
+
+phpfiles: wordpress
+	mkdir phpfiles
+	python2 extractphpfiles.py
+
+sqlfiles: sqlstmts.json
+	mkdir sqlfiles
+	python2 extractsqlfiles.py
+
+clean:
+	rm -r sqlite/
+	rm -r wordpress
+	rm -r lua
+	rm -r flowblade
+	rm sqlite.tar.gz
+	rm wordpress-4.6.13.tar.gz
+	rm sqlstmts.json
+	rm phpstmts.json
+	rm javastmts.json
+	rm luastmts.json
+	rm -r log

--- a/eco.patch
+++ b/eco.patch
@@ -1,0 +1,25 @@
+diff --git a/lib/eco/incparser/incparser.py b/lib/eco/incparser/incparser.py
+index 99ba93e..16aca4c 100644
+--- a/lib/eco/incparser/incparser.py
++++ b/lib/eco/incparser/incparser.py
+@@ -985,6 +985,7 @@ class IncParser(object):
+         # deleted ones)
+         if not node.isolated:
+             return False
++        return True
+         la = self.pop_lookahead(node)
+         return la.has_changes()
+ 
+diff --git a/lib/eco/treemanager.py b/lib/eco/treemanager.py
+index a59323f..dc0fe60 100644
+--- a/lib/eco/treemanager.py
++++ b/lib/eco/treemanager.py
+@@ -551,7 +551,7 @@ class TreeManager(object):
+                 from astanalyser import AstAnalyser
+                 return AstAnalyser(lang.nb_file)
+             else:
+-                print("Namebinding file '%s' not found." % (lang.nb_file))
++                pass#print("Namebinding file '%s' not found." % (lang.nb_file))
+ 
+ 
+     def get_languagebox(self, node):

--- a/extractjava.py
+++ b/extractjava.py
@@ -1,0 +1,43 @@
+import sys, re, os, json
+from grammars.grammars import java
+from extractor import find_subtree, remove_tabs_newlines
+
+import re
+RE_CMT = re.compile(r"}(\s|\\r)*/\*.*?\*/$", re.MULTILINE)
+
+import glob
+if __name__ == "__main__":
+    target = sys.argv[1]
+    output = sys.argv[2]
+    results = []
+    folder = "../../../javastdlib5/"
+    for filename in glob.iglob(folder+'**/**/*.java'):
+        if not filename.endswith(".java"):
+            continue
+        with open(filename) as f:
+            content = f.read()
+        content = content.replace("\n", "\r")
+        if target == "functions":
+            cond = lambda x: x.symbol.name == "method_declaration"
+        elif target == "expressions":
+            cond = lambda x: x.symbol.name == "assignment_expression"
+        expr = find_subtree(java, content, cond)
+        if expr:
+            print filename, ":", len(expr)
+            for e in expr:
+                try:
+                    e.decode("utf8")
+                    if target == "expressions":
+                        e = remove_tabs_newlines(e)
+                    else:
+                        e = RE_CMT.sub("}", e)
+                    results.append(e)
+                except UnicodeDecodeError:
+                    # we can't deal with unicode yet
+                    continue
+        else:
+            print filename, "x"
+    print "Total:", len(results)
+
+    with open(output, "w") as f:
+        json.dump(results, f, indent=0)

--- a/extractlua.py
+++ b/extractlua.py
@@ -1,0 +1,54 @@
+import sys, re, os, json
+from grammars.grammars import lua
+from extractor import find_subtree, remove_tabs_newlines
+
+def expr_filter(n):
+    return n.symbol.name == "explist"
+
+def func_filter(n):
+    if n.symbol.name == "stat" and n.children:
+        if n.children[0].symbol.name == "function":
+            return True
+        if n.children[0].symbol.name == "local" and n.children[2].symbol.name == "function":
+            return True
+    return False
+
+filters = {}
+filters["expressions"] = expr_filter
+filters["functions"] = func_filter
+
+RE_CMT = re.compile("--(.*)$")
+
+if __name__ == "__main__":
+    target = sys.argv[1]
+    output = sys.argv[2]
+    results = []
+    folder = "../../../lua/testes/"
+    for filename in os.listdir(folder):
+        if not filename.endswith(".lua"):
+            continue
+        with open(folder + filename) as f:
+            content = f.read()
+        if content.startswith("#"):
+            # remove #!
+            content = content[content.find("\n")+1:]
+        content = content.replace("\n", "\r")
+        expr = find_subtree(lua, content, filters[target])
+        if expr:
+            print filename, ":", len(expr)
+            for e in expr:
+                try:
+                    e.decode("utf8")
+                    if target == "expressions":
+                        e = remove_tabs_newlines(e)
+                        e = RE_CMT.sub("", e)
+                    results.append(e)
+                except UnicodeDecodeError:
+                    # we can't deal with unicode yet
+                    continue
+        else:
+            print filename, "x"
+    print "Total:", len(results)
+
+    with open(output, "w") as f:
+        json.dump(results, f, indent=0)

--- a/extractor.py
+++ b/extractor.py
@@ -1,0 +1,52 @@
+from treemanager import TreeManager
+from grammar_parser.gparser import Nonterminal, Terminal
+
+def next_node(node):
+    while(node.right is None):
+        node = node.parent
+    return node.right
+
+def subtree_to_text(subtree):
+    l = []
+    if subtree.children:
+        for child in subtree.children:
+            l.append(subtree_to_text(child))
+    elif type(subtree.symbol) is Terminal:
+        l.append(subtree.symbol.name)
+    return "".join(l)
+
+def remove_tabs_newlines(inp):
+    return inp.replace("\r","").replace("\t", "").replace("\n", "")
+
+def find_nonterms_by_name(tm, cond):
+    l = []
+    bos = tm.get_bos()
+    eos = tm.get_eos()
+    node = bos.right_sibling()
+    while node is not eos:
+        if cond(node):
+            l.append(node)
+            # don't traverse this node for further expressions as those are
+            # already included
+            node = next_node(node)
+            continue
+        if node.children:
+            node = node.children[0]
+            continue
+        node = next_node(node)
+    return l
+
+def find_subtree(grammar, program, cond):
+    parser, lexer = grammar.load()
+    treemanager = TreeManager()
+    treemanager.add_parser(parser, lexer, grammar.name)
+    try:
+        treemanager.import_file(program)
+    except Exception:
+        return None
+    if parser.last_status is False:
+        return None
+
+    # find all sub expressions
+    l = find_nonterms_by_name(treemanager, cond)
+    return [subtree_to_text(st).rstrip() for st in l]

--- a/extractphp.py
+++ b/extractphp.py
@@ -1,0 +1,54 @@
+import sys, re, os, json
+from grammars.grammars import php
+from extractor import find_subtree, remove_tabs_newlines
+
+def expressions_filter(n):
+    return n.symbol.name == "expr_without_variable" and n.children[0].symbol.name == "expr"
+
+def functions_filter(n):
+    #if n.symbol.name == "function_declaration_statement":
+    #    return True
+    if n.symbol.name == "class_statement":
+        return n.children[1].symbol.name == "function"
+    return False
+
+RE_HTML = re.compile("\?>(.|\n)*?<\?php")
+RE_CMT = re.compile(r"}(\s|\\r)*/\*.*?\*/$", re.MULTILINE)
+if __name__ == "__main__":
+    target = sys.argv[1]
+    output = sys.argv[2]
+    results = []
+    folder = "../../../wordpress/wp-includes/"
+    for filename in os.listdir(folder):
+        if not filename.endswith(".php"):
+            continue
+        with open(folder + filename) as f:
+            content = f.read()
+        # remove html
+        content = RE_HTML.sub("", content)
+        content = content.replace("\n", "\r")
+        if content.startswith("<?php"):
+            content = content[5:]
+        if content.endswith("?>"):
+            content = content[:-2]
+        if target == "expressions":
+            cond = expressions_filter
+        elif target == "functions":
+            cond = functions_filter
+        expr = find_subtree(php, content, cond)
+        if expr: 
+            print filename, ":", len(expr)
+            # Remove comments at the end of the expression/function
+            # Exclude functions > 1000 chars
+            for e in expr:
+                e = RE_CMT.sub("}", e)
+                if len(e) < 1000:
+                    if target == "expressions":
+                        e = remove_tabs_newlines(e)
+                    results.append(e)
+        else:
+            print filename, ": x"
+    print "Total:", len(results)
+
+    with open(output, "w") as f:
+        json.dump(results, f, indent=0)

--- a/extractphpfiles.py
+++ b/extractphpfiles.py
@@ -1,0 +1,14 @@
+import os, glob
+
+folder = "wordpress/"
+ext = "*.php"
+for d in os.walk(folder):
+    for f in d[2]:
+        if os.path.splitext(f)[1] == ".php":
+            filename = os.path.join(d[0], f)
+            with open(filename, "r") as f:
+                content = f.read()
+            if content.count("<?php") > 1:
+                continue
+            with open("phpfiles/{}".format(os.path.basename(filename)), "w") as f:
+                f.write(content.replace("<?php", ""))

--- a/extractpython.py
+++ b/extractpython.py
@@ -1,0 +1,35 @@
+import sys, re, os, json
+from grammars.grammars import python
+from extractor import find_subtree, remove_tabs_newlines
+
+def expr_filter(n):
+    return n.symbol.name == "testlist" and n.left_sibling()
+
+if __name__ == "__main__":
+    output = sys.argv[1]
+    results = []
+    folder = "../../../flowblade/flowblade-trunk/Flowblade/"
+    for filename in os.listdir(folder):
+        if not os.path.splitext(filename)[1] == ".py":
+            continue
+        with open(os.path.join(folder, filename)) as f:
+            content = f.read()
+        # remove html
+        content = content.replace("\n", "\r")
+        expr = find_subtree(python, content, expr_filter)
+        sys.stdout.flush()
+        if expr:
+            print filename, ":", len(expr)
+            for e in expr:
+                try:
+                    e.decode("utf8")
+                    e = remove_tabs_newlines(e)
+                    results.append(e)
+                except UnicodeDecodeError:
+                    # we can't deal with unicode yet
+                    continue
+        else:
+            print filename, "x"
+
+    with open(output, "w") as f:
+        json.dump(results, f, indent=0)

--- a/extractsqlfiles.py
+++ b/extractsqlfiles.py
@@ -1,0 +1,17 @@
+import os, json
+
+with open("sqlstmts.json") as f:
+    l = json.load(f)
+exprs = ["CHECK", "ON", "LIMIT", "KEY", "HAVING", "FOLLOWING", "PRECEDING", "ELSE", "WHEN", "WHERE",
+         "VALUES", "INTO", "DEFAULT", "ATTACH", "DETACH", "COLLATE", "ORDER", "CAST", "ID", "INDEXED"]
+
+i = 0
+for s in l:
+    for e in exprs:
+        if s.find(e) > -1:
+            with open("sqlfiles/{}.sql".format(i), "w") as f:
+                try:
+                    f.write(s)
+                except UnicodeEncodeError:
+                    continue
+    i += 1

--- a/extractsqlstmts.py
+++ b/extractsqlstmts.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python2.7
+
+import sys
+import re, os, json
+from time import time
+from grammars.grammars import sqlite
+from grammar_parser.gparser import Terminal
+from treelexer.lexer import Lexer
+from incparser.syntaxtable import FinishSymbol, Reduce, Accept, Shift
+
+class Parser(object):
+
+    def __init__(self, stable):
+        self.stable = stable
+        self.state = 0
+        self.stack = [("$", 0)]
+        self.log = []
+
+    def parse(self, tokens):
+        self.log = []
+        tokens = iter(tokens)
+        token = tokens.next()
+        la = Terminal(token[1])
+        while True:
+            self.log.append(token)
+            elem = self.stable.lookup(self.state, la)
+            if type(elem) is Shift:
+                self.state = elem.action
+                self.stack.append((la, self.state))
+                try:
+                    token = tokens.next()
+                    la = Terminal(token[1])
+                except StopIteration:
+                    la = FinishSymbol()
+            elif type(elem) is Reduce:
+                for i in range(elem.amount()):
+                    self.stack.pop()
+                self.state = self.stack[-1][1]
+                goto = self.stable.lookup(self.state, elem.action.left)
+                assert goto != None
+                self.state = goto.action
+                self.stack.append((elem.action.left, self.state))
+            elif type(elem) is Accept:
+                return True
+            else:
+                return False
+
+if __name__ == "__main__":
+    jsonfile = sys.argv[1]
+    with open(jsonfile) as f:
+        s = json.load(f)
+    
+    incparser, inclexer = sqlite.load()
+    lexer = inclexer.lexer
+    stable = incparser.syntaxtable
+
+    working = []
+    failed = []
+
+    for stmt in s:
+        stmt2 = stmt.replace("\n", "\r") # Eco grammar compatiblity fix
+        # append semicolon to tests where it's missing
+        if not stmt2.endswith(";"):
+            stmt2 = stmt2 + ";"
+        tokens = lexer.lex(stmt2)
+        parser = Parser(stable)
+        success = False
+        e = None
+        try:
+            success = parser.parse(tokens)
+        except TypeError, e:
+            pass
+        if not success:
+            failed.append(stmt2)
+            sys.stdout.write("x")
+            sys.stdout.flush()
+        else:
+            working.append(stmt2)
+            sys.stdout.write(".")
+            sys.stdout.flush()
+
+    with open("../../../sqlstmts.json", "w") as f:
+        json.dump(working, f, indent=0)
+
+    with open("../../../sqlstmts_fail.json", "w") as f:
+        json.dump(failed, f, indent=0)

--- a/extractsqltests.py
+++ b/extractsqltests.py
@@ -1,0 +1,21 @@
+import re, os, json
+
+re_stmt = re.compile("{\s*((DELETE|SELECT|PRAGMA|INSERT|UPDATE|CREATE|DROP|ALERT|BEGIN|ATTACH)([^}]*))\s*}", re.MULTILINE)
+result = []
+
+for filename in os.listdir("sqlite/test"):
+    if not filename.endswith("test"):
+        continue
+    with open("sqlite/test/{}".format(filename)) as f:
+        source = f.read()
+        for m in re_stmt.finditer(source):
+            c = m.group(1)
+            lines = m.group(1).splitlines()
+            if lines:
+                # Test if program is valid in SQL
+                s = "\n".join(lines)
+                s = s.replace("\n", "\r") # Eco grammar compatiblity fix
+                result.append("\n".join(lines))
+
+with open("sqltests.json", "w") as output:
+    json.dump(result, output, indent=0)

--- a/fuzzylboxstats.py
+++ b/fuzzylboxstats.py
@@ -1,0 +1,388 @@
+import random, json, glob, os
+from grammars.grammars import lang_dict, EcoFile
+from treemanager import TreeManager
+from grammar_parser.gparser import Nonterminal, Terminal
+from incparser.astree import MultiTextNode
+
+# helper functions
+
+debug = False
+MAX_FILES = 100
+
+def next_node(node):
+    while(node.right is None):
+        node = node.parent
+    return node.right
+
+def prev_node(node):
+    while(node.left is None):
+        node = node.parent
+    return node.left
+
+def subtree_to_text(subtree):
+    l = []
+    if subtree.children:
+        for child in subtree.children:
+            l.append(subtree_to_text(child))
+    elif type(subtree.symbol) is Terminal:
+        l.append(subtree.symbol.name)
+    return "".join(l).replace("\r", "").replace("\t", "").replace("\n", "")
+
+def truncate(string):
+    if len(string) > 40:
+        return repr(string[:20] + "..." + string[-20:])
+    else:
+        return repr(string)
+
+def validnonterm(node, symbol):
+    if not isinstance(node.symbol, Nonterminal):
+        return False
+    if node.symbol.name != symbol:
+        return False
+    if node.symbol.name == "class_statement": # PHP func
+        return node.children[1].symbol.name == "function"
+    elif node.symbol.name == "expr_without_variable": # PHP expr
+        return node.children[0].symbol.name == "expr"
+    elif node.symbol.name == "testlist": # Python expr
+        # Only replace RHS of expressions, because there's currently a bug that
+        # keeps indentation terminals from being inserted before language boxes
+        return node.left_sibling() is not None
+    elif node.symbol.name == "stat": # Lua func
+        if node.children:
+            if node.children[0].symbol.name == "function":
+                return True
+            if node.children[0].symbol.name == "local" and node.children[2].symbol.name == "function":
+                return True
+        return False
+    return True
+
+class FuzzyLboxStats:
+
+    def __init__(self, main, sub):
+        parser, lexer = main.load()
+        self.lexer = lexer
+        self.parser = parser
+        self.ast = parser.previous_version
+        self.treemanager = TreeManager()
+        self.treemanager.add_parser(parser, lexer, main.name)
+        self.treemanager.option_autolbox_insert = True
+        self.langname = main.name
+
+        parser.setup_autolbox(main.name)
+        self.sub = sub
+
+        self.inserted = 0
+
+        self.faillog = []
+        self.multilog = []
+
+    def load_main(self, filename):
+        self.filename = filename
+        f = open(filename, "r")
+        self.content = f.read()
+        f.close()
+        self.content.replace("\n", "\r")
+        self.treemanager.import_file(self.content)
+        self.mainexprs = self.find_nonterms_by_name(self.treemanager, self.main_repl_str)
+        self.minver = self.treemanager.version
+
+    def reset(self):
+        self.parser.reset()
+        self.treemanager = TreeManager()
+        self.treemanager.add_parser(self.parser, self.lexer, self.langname)
+        self.treemanager.import_file(self.content)
+        self.mainexprs = self.find_nonterms_by_name(self.treemanager, self.main_repl_str)
+
+    def load_expr(self, filename):
+        f = open(filename, "r")
+        content = f.read()
+        f.close()
+        self.replexprs = self.find_expressions(content, self.sub_repl_str)
+
+    def load_expr_from_json(self, filename):
+        import json
+        with open(filename) as f:
+            self.replexprs = json.load(f)
+
+    def set_replace(self, main, sub):
+        self.main_repl_str = main
+        self.sub_repl_str = sub
+
+    def find_nonterms_by_name(self, tm, name):
+        l = []
+        bos = tm.get_bos()
+        eos = tm.get_eos()
+        node = bos.right_sibling()
+        while node is not eos:
+            if validnonterm(node, name):
+                l.append(node)
+                node = next_node(node)
+                continue
+            if node.children:
+                node = node.children[0]
+            else:
+                node = next_node(node)
+        return l
+
+    def find_expressions(self, program, expr):
+        parser, lexer = self.sub.load()
+        treemanager = TreeManager()
+        treemanager.add_parser(parser, lexer, self.sub.name)
+        treemanager.import_file(program)
+
+        # find all sub expressions
+        l = self.find_nonterms_by_name(treemanager, expr)
+        return [subtree_to_text(st).rstrip() for st in l]
+
+    def insert_python_expression(self, expr):
+        for c in expr:
+            self.treemanager.key_normal(c)
+
+    def delete_expr(self, expr):
+        # find first term and last term
+        # select + delete
+        node = expr
+        while type(node.symbol) is Nonterminal:
+            if node.children:
+                node = node.children[0]
+            else:
+                node = next_node(node)
+        first = node
+        if isinstance(first, MultiTextNode):
+            first = first.children[0]
+
+        node = expr
+        while type(node.symbol) is Nonterminal:
+            if node.children:
+                node = node.children[-1]
+            else:
+                node = prev_node(node)
+        while node.lookup == "<ws>" or node.lookup == "<return>":
+            node = node.prev_term
+        last = node
+        if isinstance(last, MultiTextNode):
+            last = last.children[-1]
+
+        if first.deleted or last.deleted:
+            return None
+
+        self.treemanager.select_nodes(first, last)
+        deleted = self.treemanager.copySelection()
+        self.treemanager.deleteSelection()
+        return deleted
+
+    def multi_len(self, autos):
+        r = []
+        for start, end, _ in autos:
+            l = 0
+            while start is not end:
+                l += len(start.symbol.name)
+                start = start.next_term
+            r.append(l)
+        return r
+
+    def run(self, main_samples=None, sub_samples=None):
+        assert len(self.treemanager.parsers) == 1
+
+        ops = self.main_repl_str, len([subtree_to_text(x) for x in self.mainexprs])
+        preversion = self.treemanager.version
+
+        inserted_error = 0
+        inserted_valid = 0
+        noinsert_error = 0
+        noinsert_valid = 0
+        noinsert_multi = 0
+
+        # pick random exprs from main
+        if not main_samples:
+            samplesize = 10
+            if len(self.mainexprs) < 10:
+                samplesize = len(self.mainexprs)
+            sample = random.sample(range(len(self.mainexprs)), samplesize) # store this for repeatability
+            exprchoices = [self.mainexprs[i] for i in sample]
+            self.main_samples = sample
+        else:
+            self.main_samples = main_samples
+            exprchoices = [self.mainexprs[i] for i in main_samples]
+
+        if not sub_samples:
+            # pick random exprs from sub
+            sample = random.sample(range(len(self.replexprs)), len(exprchoices))
+            replchoices = [self.replexprs[i] for i in sample]
+            self.sub_samples = sample
+        else:
+            self.sub_samples = sub_samples
+            replchoices = [self.replexprs[i] for i in sub_samples]
+
+        for i, e in enumerate(exprchoices):
+            if e.get_root() is None:
+                continue
+            before = len(self.treemanager.parsers)
+            deleted = self.delete_expr(e)
+            if deleted:
+                choice = replchoices[i]
+                if debug: print "  Replacing '{}' with '{}':".format(truncate(deleted), choice)
+                self.insert_python_expression(choice)
+                valid = self.parser.last_status
+                if before == len(self.treemanager.parsers):
+                    if len(self.parser.error_nodes) > 0 and self.parser.error_nodes[0].autobox and len(self.parser.error_nodes[0].autobox) > 1:
+                        noinsert_multi += 1
+                        result = "No box inserted (Multi)"
+                        self.faillog.append(("multi", self.filename, repr(deleted), repr(choice)))
+                        multis = self.multi_len(self.parser.error_nodes[0].autobox)
+                        self.multilog.append(multis)
+                    elif valid:
+                        noinsert_valid += 1
+                        result = "No box inserted (Valid)"
+                        self.faillog.append(("valid", self.filename, repr(deleted), repr(choice)))
+                    else:
+                        noinsert_error += 1
+                        result = "No box inserted (Error)"
+                        self.faillog.append(("error", self.filename, repr(deleted), repr(choice)))
+                else:
+                    result = "Box inserted"
+                    self.inserted += 1
+                    if valid:
+                        inserted_valid += 1
+                        self.faillog.append(("ok", self.filename, repr(deleted), repr(choice)))
+                    else:
+                        inserted_error += 1
+                        self.faillog.append(("inerr", self.filename, repr(deleted), repr(choice)))
+                if debug: print "    => {} ({})".format(result, valid)
+            else:
+                if debug: print "Replacing '{}' with '{}':\n    => Already deleted".format(truncate(subtree_to_text(e)), truncate(choice))
+            self.undo(self.minver)
+        if debug:
+            print("Boxes inserted: {}/{}".format(self.inserted, ops))
+            print("Valid insertions:", inserted_valid)
+            print("Invalid insertions:", inserted_error)
+            print("No insertion (valid):", noinsert_valid)
+            print("No insertion (error):", noinsert_error)
+            print("No insertion (multi):", noinsert_multi)
+        return (inserted_valid, inserted_error, noinsert_valid, noinsert_error, noinsert_multi)
+
+    def undo(self, version):
+        while self.treemanager.version != version:
+            before = self.treemanager.version
+            self.treemanager.version -= 1
+            self.treemanager.recover_version("undo", self.treemanager.version + 1)
+            self.treemanager.cursor.load(self.treemanager.version, self.treemanager.lines)
+            if before == self.treemanager.version:
+                exit("Error")
+
+def run_multi(name, main, sub, folder, ext, exprs, mrepl, srepl=None, config=None):
+    if config:
+        run_config(name, main, sub, config, exprs, mrepl)
+        return
+    runcfg = []
+    results = []
+    faillog = []
+    multilog = []
+    files = [y for x in os.walk(folder) for y in glob.glob(os.path.join(x[0], ext))]
+    if len(files) > MAX_FILES:
+        # let's limit files to 200 for now
+        files = random.sample(files, MAX_FILES)
+    i = 0
+    for filename in files:
+        c, r, f, m = run_single(filename, main, sub, exprs, mrepl, srepl)
+        if c is None:
+            continue
+        runcfg.append(c)
+        results.append(r)
+        faillog.extend(f)
+        multilog.extend(m)
+        i = i + sum(r)
+        if i > 1000:
+            # abort after 1000 insertions
+            break
+    with open("{}_run.json".format(name), "w") as f: json.dump(runcfg, f, indent=0)
+    with open("{}_log.json".format(name), "w") as f: json.dump(results, f)
+    with open("{}_fail.json".format(name), "w") as f: json.dump(faillog, f, indent=0)
+    with open("{}_multi.json".format(name), "w") as f: json.dump(multilog, f, indent=0)
+    print
+
+def run_single(filename, main, sub, exprs, mrepl, srepl, msample=None, ssample=None):
+    if debug: print("Runsingle:", filename)
+    fuz = FuzzyLboxStats(main, sub)
+    fuz.set_replace(mrepl, srepl)
+    try:
+        fuz.load_main(filename)
+        fuz.load_expr_from_json(exprs)
+        r = fuz.run(msample, ssample)
+    except Exception, e:
+        # We only care about files that parse initially
+        sys.stdout.write("s")
+        sys.stdout.flush()
+        return None, None, None, None
+    if r[1] > 0 or r[3] > 0:
+        # insert_error and noinsert_error
+        sys.stdout.write("x")
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(".")
+        sys.stdout.flush()
+    config = (filename, fuz.main_samples, fuz.sub_samples)
+    return config, r, fuz.faillog, fuz.multilog
+
+def run_config(name, main, sub, configdir, exprs, mrepl, srepl=None):
+    with open("{}/{}_run.json".format(configdir, name)) as f:
+        log = []
+        faillog = []
+        multilog = []
+        config = json.load(f)
+        for filename, msample, ssample in config:
+            c, r, f, m = run_single(filename, main, sub, exprs, mrepl, srepl, msample, ssample)
+            if c is None:
+                continue
+            log.append(r)
+            faillog.extend(f)
+            multilog.extend(m)
+        with open("{}_log.json".format(name), "w") as f: json.dump(log, f)
+        with open("{}_fail.json".format(name), "w") as f: json.dump(faillog, f, indent=0)
+        with open("{}_multi.json".format(name), "w") as f: json.dump(multilog, f, indent=0)
+        print
+
+def create_composition(smain, ssub, mainexpr, gmain, gsub, subexpr, histtok):
+    sub = EcoFile(ssub, "grammars/" + gsub, ssub)
+    if subexpr:
+        sub.name = sub.name + " expr"
+        sub.change_start(subexpr)
+
+    main = EcoFile(smain + " + " + ssub, "grammars/" + gmain, smain)
+    main.auto_limit_new = histtok
+    main.add_alternative(mainexpr, sub)
+    lang_dict[main.name] = main
+    lang_dict[sub.name] = sub
+
+    return main
+
+if __name__ == "__main__":
+    import sys
+    args = sys.argv
+    wd = "/home/lukas/research/auto_lbox_experiments/"
+
+    if len(args) < 8:
+        print("Missing arguments.\nUsage: python2 fuzzylboxstats.py MAINGRM MAINRULE SUBGRM SUBRULE FILES EXTENSION REPLACMENTS HISTORICTOKEN [RERUNDIR]")
+        exit()
+
+    maingrm = args[1]
+    mainrule = args[2]
+    subgrm = args[3]
+    subrule = args[4]
+    files = args[5]
+    ext = args[6]
+    repl = args[7]
+    if args[8] == "True":
+        histtok = True
+    else:
+        histtok = False
+    if len(args) > 9:
+        rerunconfig = wd + args[9]
+    else:
+        rerunconfig = None
+    if subrule == "None":
+        subrule = None
+
+    comp = create_composition("Main", "Sub", mainrule, maingrm, subgrm, subrule, histtok)
+    name = maingrm[:-4] + subgrm[:-4]
+    run_multi(name, comp, None, "{}/{}/".format(wd, files), '*.{}'.format(ext), "{}/{}".format(wd, repl), mainrule, subrule, rerunconfig)

--- a/h1.patch
+++ b/h1.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/eco/autolboxdetector.py b/lib/eco/autolboxdetector.py
+index 6aa3190..a1b6e06 100644
+--- a/lib/eco/autolboxdetector.py
++++ b/lib/eco/autolboxdetector.py
+@@ -62,9 +62,7 @@ class NewAutoLboxDetector(object):
+     def detect_lbox(self, errornode):
+         # Try heuristic #2 first; if it fails to find an automatic language
+         # box, try heuristic #1
+-        valid = self.detect_lbox_h2(errornode)
+-        if not valid:
+-            valid = self.detect_lbox_h1(errornode)
++        valid = self.detect_lbox_h1(errornode)
+ 
+         if errornode.autobox is False:
+             # XXX Currently, we don't suggest any language boxes for an error,

--- a/h2.patch
+++ b/h2.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/eco/autolboxdetector.py b/lib/eco/autolboxdetector.py
+index 6aa3190..18a0e4a 100644
+--- a/lib/eco/autolboxdetector.py
++++ b/lib/eco/autolboxdetector.py
+@@ -63,8 +63,6 @@ class NewAutoLboxDetector(object):
+         # Try heuristic #2 first; if it fails to find an automatic language
+         # box, try heuristic #1
+         valid = self.detect_lbox_h2(errornode)
+-        if not valid:
+-            valid = self.detect_lbox_h1(errornode)
+ 
+         if errornode.autobox is False:
+             # XXX Currently, we don't suggest any language boxes for an error,


### PR DESCRIPTION
Unfortunately, I couldn't salvage any of the commit messages from the init branch, which is why this is only a single commit. However, to help the review I will explain in the following what the different files are:

- **Makefile**: The make script to run the experiments. There are two experiments we currently care about: composing expressions (`make comp_exprs`) and composing functions (`make comp_funcs`) (both can be run with `-j` for a significant speedup). Note the two environment variables `RERUNDIR` and `HISTOK`, with which we can further influence the experiment. We probably want to create a single-command batch file later on, which runs all the experiments with all possible options. Also note, that the dependency `javastdlib5` cannot be automatically downloaded. We probably want to provide a description on where and how this can be retrieved (similar to https://github.com/softdevteam/eco_benchmark).
- **eco.patch**: Makes sure that isolated subtrees are always inspected (which only seems to be a problem in the experiment). Also gets rid of a command line print.
- **h1.patch and h2.patch**: Used to toggle between the heuristics. By default both heuristics are active.
- **extractor.py**: Script to load Java/PHP/etc. programs into Eco and extract subtrees from the parse tree. Used by the extraction-scripts `extract[java|lua|php|python|sqlstmts]`.
- **extractsqlfiles.py**: Generates SQL programs from the extracted SQL statements, to be used when running SQL+X compositions.
- **extractsqltest.py**: Extracts all tests from the sqlite repo. Used to further extract SQL statements from.