### PR TITLE
Update dependencies

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,7 +5,8 @@ Benchmark automatic language boxes in Eco.
 ## Requirements
 
 - Python2
-- (Optional) PyPy
+- lib32z1
+- (Optional) PyPy (improves runtime of the experiment)
 - (Optional) PyQt4
 
 ## Quickstart


### PR DESCRIPTION
In order to extract the Java Standard Library 5 dependency `lib32z1` is required.

Fixes #8